### PR TITLE
pkgbuild: option to only build and package 

### DIFF
--- a/pkgadd
+++ b/pkgadd
@@ -318,8 +318,8 @@ if [ -f $INDEX_DIR/$name/.pkginstall ]; then
 fi
 
 # running ldconfig
-if [ -x "$ROOT_DIR"/sbin/ldconfig ]; then
-	$ROOT_DIR/sbin/ldconfig -r "$ROOT_DIR"/
-fi
+#if [ -x "$ROOT_DIR"/sbin/ldconfig ]; then
+#	$ROOT_DIR/sbin/ldconfig -r "$ROOT_DIR"/
+#fi
 
 ret 0

--- a/pkgadd
+++ b/pkgadd
@@ -318,8 +318,8 @@ if [ -f $INDEX_DIR/$name/.pkginstall ]; then
 fi
 
 # running ldconfig
-#if [ -x "$ROOT_DIR"/sbin/ldconfig ]; then
-#	$ROOT_DIR/sbin/ldconfig -r "$ROOT_DIR"/
-#fi
+if [ -x "$ROOT_DIR"/sbin/ldconfig ]; then
+	$ROOT_DIR/sbin/ldconfig -r "$ROOT_DIR"/
+fi
 
 ret 0

--- a/pkgbuild
+++ b/pkgbuild
@@ -486,6 +486,7 @@ parse_opts() {
 		-g |          --genmdsum) UPDATE_MDSUM=yes ;;
 		-o |          --download) DOWNLOAD_ONLY=yes ;;
 		-x |           --extract) EXTRACT_ONLY=yes ;;
+		-b |        --only-build) BUILD_ONLY=yes ;;
 		-w |         --keep-work) KEEP_WORK=yes ;;
 		-l |               --log) LOGGING=yes ;;
 		-h |              --help) SHOWHELP=yes ;;
@@ -522,6 +523,7 @@ Options:
   -g, --genmdsum            generate md5sum
   -o, --download            download only source file
   -x, --extract             extract only source file
+  -b, --build-only          build and package without downloading and extracting source             
   -w, --keep-work           keep working directory
   -l, --log                 log build process
   -h, --help                show this help message
@@ -626,6 +628,20 @@ main() {
 		prepare_src
 		KEEP_WORK=yes
 		abort 0
+	fi 
+
+	# build and package without downloading and extracting source
+	if [ "$BUILD_ONLY" ]; then
+		if [ -f "$PACKAGE_DIR/$PKGNAME" ] && [ ! "$FORCE_REBUILD" ]; then
+		    if [ ! "$INSTALL_PKG" ] && [ ! "$REINSTALL_PKG" ] && [ ! "$UPGRADE_PKG" ]; then
+			    echo "Package '$PKGNAME' is up-to-date."
+			    abort 0
+		    fi
+	    else
+            run_build
+		    packaging
+		    clearworkdir
+	    fi
 	fi
 	
 	# calculate & print md5sum

--- a/pkgbuild.8
+++ b/pkgbuild.8
@@ -45,6 +45,9 @@ download only source file
 .B "-x, --extract"
 extract only source file
 .TP
+.B "-x, --extract"
+build and package without downloading and extracting source
+.TP
 .B "-w, --keep-work"
 keep working directory
 .TP

--- a/pkgbuild.8
+++ b/pkgbuild.8
@@ -45,7 +45,7 @@ download only source file
 .B "-x, --extract"
 extract only source file
 .TP
-.B "-x, --extract"
+.B "-b, "--build-only"
 build and package without downloading and extracting source
 .TP
 .B "-w, --keep-work"


### PR DESCRIPTION
Greetings, this pull request is adding a `--build-only` flag to `pkgbuild`, this feature only builds and packages the particular package your targeting without downloading and extracting the source files. (This is assuming you have already downloaded them.)

Think this will go well with building automation scripts to utilize this flag where chroot's don't have `wget` or `curl` already installed. Let me know if you have any questions. 